### PR TITLE
Pivital tools of managing slices of all types and dynamically allocat…

### DIFF
--- a/src/core/utils/slice_int/slice_int.go
+++ b/src/core/utils/slice_int/slice_int.go
@@ -1,0 +1,19 @@
+package slice_int
+
+func Init() []int {
+    return make([]int, 0, 1)
+}
+
+func Extend(slice []int, element int) []int {
+    n := len(slice)
+    if n == cap(slice) {
+        // Slice is full; must grow.
+        // We double its size and add 1, so if the size is zero we still grow.
+        newSlice := make([]int, len(slice), 2*len(slice)+1)
+        copy(newSlice, slice)
+        slice = newSlice
+    }
+    slice = slice[0 : n+1]
+    slice[n] = element
+    return slice
+}

--- a/src/core/utils/slice_string/slice_string.go
+++ b/src/core/utils/slice_string/slice_string.go
@@ -1,0 +1,19 @@
+package slice_string
+
+func Init() []string {
+    return make([]string, 0, 1)
+}
+
+func Extend(slice []string, element string) []string {
+    n := len(slice)
+    if n == cap(slice) {
+        // Slice is full; must grow.
+        // We double its size and add 1, so if the size is zero we still grow.
+        newSlice := make([]string, len(slice), 2*len(slice)+1)
+        copy(newSlice, slice)
+        slice = newSlice
+    }
+    slice = slice[0 : n+1]
+    slice[n] = element
+    return slice
+}

--- a/src/core/utils/slice_struct/slice_struct.go
+++ b/src/core/utils/slice_struct/slice_struct.go
@@ -1,0 +1,19 @@
+package slice_struct
+
+func Init() []interface{} {
+    return make([]interface{}, 0, 1)
+}
+
+func Extend(slice []interface{}, element interface{}) []interface{} {
+    n := len(slice)
+    if n == cap(slice) {
+        // Slice is full; must grow.
+        // We double its size and add 1, so if the size is zero we still grow.
+        newSlice := make([]interface{}, len(slice), 2*len(slice)+1)
+        copy(newSlice, slice)
+        slice = newSlice
+    }
+    slice = slice[0 : n+1]
+    slice[n] = element
+    return slice
+}


### PR DESCRIPTION
Dan we probably should make all our package folder names lower case so that we can do something like package_name.Function().  It looks cleaner than packageName.Function().  Since all exportable and accessible package methods must start with a Capital letter, the double camel case is not very aesthetically pleasing.

Heres a Test of these methods which I wrote to dynamically allocate a slice based on a slice of ints, strings or structs.

Notice the use of interface to allow any kinds of struct classes passed to a "list or array" of structs.

You only used interface{} once in your core code here `func RespondJSON(v interface{}, c *gin.Context)`.  Now you can basically use a slice_int.Make() to create a new array of ints easily and then you can easily add new indexes dynamically like you would in an interpretted language with .append

```


import "core/utils/slice_int"
import "core/utils/slice_string"
import "core/utils/slice_struct"

func main() {
    type Rectangle struct {
        length, width int
        name string
    }
    // slice of ints
    slice := slice_int.Init()
    for i := 0; i < 10; i++ {
        slice = slice_int.Extend(slice, i)
    }

    // slice of strings
    slice2 := slice_string.Init()
    slice2 = slice_string.Extend(slice2, "asdf")
    fmt.Printf("len=%d cap=%d slice=%v\n", len(slice2), cap(slice2), slice2)
    fmt.Println("address of 0th element:", &slice2[0])

    // slice of objects
    slice3 := slice_struct.Init()
    slice3 = slice_struct.Extend(slice3, Rectangle{width: 1234, length: 4444, name: "Dan"})
    fmt.Printf("len=%d cap=%d slice=%v\n", len(slice3), cap(slice3), slice3)
    fmt.Println("address of 0th element:", &slice3[0])
    adsf := new (Rectangle)
    adsf.length = 12
    adsf.width = 12
    adsf.name = "dave"
    slice3 = slice_struct.Extend(slice3, adsf)
    fmt.Printf("len=%d cap=%d slice=%v\n", len(slice3), cap(slice3), slice3)
    fmt.Println("address of 0th element:", &slice3[0])

    for _, rect := range slice3 {
        //fmt.Printf("Name: %s length: %d width: %d\n", rect[_].name, rect.length, rect.width)
        fmt.Println(rect)
    }
}
```

I do have a question for you though.  How can I get the attribute ".name" from a rect in the loop at the bottom of the example?

Read up on the ... operator to for variadic parameters which is very nice in python

http://changelog.ca/log/2015/01/30/golang
