### PR TITLE
Remove deprecated package

### DIFF
--- a/core/appGen/appGenFiles.go
+++ b/core/appGen/appGenFiles.go
@@ -231,7 +231,6 @@ webConfig.json
 package settings
 
 import (	
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -269,7 +268,7 @@ func Initialize() {
 	}
 	ServerSettings = serverSettings.WebConfig.Application
 
-	jsonData, err := ioutil.ReadFile(serverSettings.APP_LOCATION + "/webConfig.json")
+	jsonData, err := os.ReadFile(serverSettings.APP_LOCATION + "/webConfig.json")
 	if err != nil {
 		log.Println("Reading of webConfig.json failed at settings.init():  " + err.Error())
 		os.Exit(1)

--- a/core/dbServices/bolt/stubs/model.go
+++ b/core/dbServices/bolt/stubs/model.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -752,7 +751,7 @@ func BootstrapDirectory(directoryName string, collectionCount int) (files [][]by
 
 			go func() {
 				defer wg.Done()
-				jsonData, err := ioutil.ReadFile(path)
+				jsonData, err := os.ReadFile(path)
 				if err != nil {
 					return
 				}

--- a/core/dbServices/createDBServices.go
+++ b/core/dbServices/createDBServices.go
@@ -13,7 +13,6 @@ import (
 
 	// "fmt"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,7 +175,7 @@ func (a SchemaNameSorter) Less(i, j int) bool { return a[i].Schema.Name < a[j].S
 
 func RunDBCreate() {
 
-	// jsonData, err := ioutil.ReadFile("db/" + serverSettings.WebConfig.DbConnection.AppName + "/create.json")
+	// jsonData, err := os.ReadFile("db/" + serverSettings.WebConfig.DbConnection.AppName + "/create.json")
 	// if err != nil {
 	// 	fmt.Println("Reading of create.json failed:  " + err.Error())
 	// 	return
@@ -221,7 +220,7 @@ func walkNoSQLSchema() {
 	allCollections.Unlock()
 	basePath := serverSettings.APP_LOCATION + "/db/schemas"
 
-	fileNames, errReadDir := ioutil.ReadDir(basePath)
+	fileNames, errReadDir := os.ReadDir(basePath)
 	if errReadDir != nil {
 		color.Red("Reading of " + basePath + " failed:  " + errReadDir.Error())
 		return
@@ -236,7 +235,7 @@ func walkNoSQLSchema() {
 			versionDir := "v" + version.MajorString
 			walkNoSQLVersion(basePath+"/"+file.Name(), versionDir)
 
-			goFileNames, errGoReadDir := ioutil.ReadDir(serverSettings.APP_LOCATION + "/db/goFiles/v" + version.MajorString)
+			goFileNames, errGoReadDir := os.ReadDir(serverSettings.APP_LOCATION + "/db/goFiles/v" + version.MajorString)
 
 			if errGoReadDir == nil {
 				for _, file := range goFileNames {
@@ -301,7 +300,7 @@ func walkNoSQLVersion(path string, versionDir string) {
 		var e error
 
 		if filepath.Ext(f.Name()) == ".json" {
-			jsonData, err := ioutil.ReadFile(path)
+			jsonData, err := os.ReadFile(path)
 			if err != nil {
 				color.Red("Reading in walkNoSQLVersion of " + path + " failed:  " + err.Error())
 				e = err
@@ -608,7 +607,7 @@ func generateNoSQLModelBucket(driver string) string {
 
 func writeNoSQLWebAPI(value string, path string, collection NOSQLCollection) {
 
-	err := ioutil.WriteFile(path, []byte(value), 0777)
+	err := os.WriteFile(path, []byte(value), 0777)
 	if err != nil {
 		color.Red("Error creating Web API for Collection " + collection.Name + ":  " + err.Error())
 		return
@@ -636,7 +635,7 @@ func copyNoSQLStub(source string, dest string) {
 
 func writeNoSQLStub(value string, path string) {
 
-	err := ioutil.WriteFile(path, []byte(value), 0777)
+	err := os.WriteFile(path, []byte(value), 0777)
 	if err != nil {
 		color.Red("Failed to write stub file to " + path + ":  " + err.Error())
 		return
@@ -654,7 +653,7 @@ func writeNoSQLStub(value string, path string) {
 
 func writeNoSQLModelCollection(value string, path string, collection NOSQLCollection) {
 
-	err := ioutil.WriteFile(path, []byte(value), 0777)
+	err := os.WriteFile(path, []byte(value), 0777)
 	if err != nil {
 		color.Red("Error creating Model for Collection " + collection.Name + ":  " + err.Error())
 		return
@@ -671,7 +670,7 @@ func writeNoSQLModelCollection(value string, path string, collection NOSQLCollec
 
 func writeNOSQLModelBucket(value string, path string) {
 
-	err := ioutil.WriteFile(path, []byte(value), 0777)
+	err := os.WriteFile(path, []byte(value), 0777)
 	if err != nil {
 		color.Red("Error creating Model for Bucket:  " + err.Error())
 		return

--- a/core/extensions/fileExtensions.go
+++ b/core/extensions/fileExtensions.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -42,7 +41,7 @@ func GetAllFiles(path string) (files []os.FileInfo, err error) {
 // GetAllFilesWithSearch returns all files in a directory with a search string
 func GetAllFilesWithSearch(path string, fileSearch string) (files []os.FileInfo, err error) {
 	files = make([]os.FileInfo, 0)
-	filesAll, err := ioutil.ReadDir(path)
+	filesAll, err := os.ReadDir(path)
 	if err == nil {
 		for _, file := range filesAll {
 			if !file.IsDir() {
@@ -63,7 +62,7 @@ func GetAllFolders(path string) (files []os.FileInfo, err error) {
 // GetAllFoldersWithSearch returns all folders in a directory with a search string
 func GetAllFoldersWithSearch(path string, fileSearch string) (files []os.FileInfo, err error) {
 	files = make([]os.FileInfo, 0)
-	filesAll, err := ioutil.ReadDir(path)
+	filesAll, err := os.ReadDir(path)
 	if err == nil {
 		for _, file := range filesAll {
 			if file.IsDir() {
@@ -79,7 +78,7 @@ func GetAllFoldersWithSearch(path string, fileSearch string) (files []os.FileInf
 // GetAllFilesDeepWithSearch recursively returns all files in a directory with a search string
 func GetAllFilesDeepWithSearch(path string, fileSearch string) (files []os.FileInfo, err error) {
 	files = make([]os.FileInfo, 0)
-	filesAll, err := ioutil.ReadDir(path)
+	filesAll, err := os.ReadDir(path)
 	if err == nil {
 		for _, file := range filesAll {
 			if !file.IsDir() {
@@ -101,7 +100,7 @@ func GetAllFilesDeepWithSearch(path string, fileSearch string) (files []os.FileI
 // GetAllFilesSearchWithPath returns all files in a directory with a search string
 func GetAllFilesSearchWithPath(path string, fileSearch string) (files []FilePath, err error) {
 	files = make([]FilePath, 0)
-	filesAll, err := ioutil.ReadDir(path)
+	filesAll, err := os.ReadDir(path)
 	if err == nil {
 		for _, file := range filesAll {
 			if !file.IsDir() {
@@ -139,7 +138,7 @@ func GetAllDirs(path string) (files []os.FileInfo, err error) {
 // GetAllDirWithExclude returns all directories in a directory excluding the exclude string
 func GetAllDirWithExclude(path string, except string) (files []os.FileInfo, err error) {
 	files = make([]os.FileInfo, 0)
-	filesAll, err := ioutil.ReadDir(path)
+	filesAll, err := os.ReadDir(path)
 	if err == nil {
 		for _, file := range filesAll {
 			if file.IsDir() {
@@ -288,7 +287,7 @@ func WriteAndGoFormat(value string, path string) error {
 // WriteAndGoFmt writes a file and formats it with go
 func WriteAndGoFmt(value string, path string, quiet bool, perm os.FileMode) error {
 
-	err := ioutil.WriteFile(path, []byte(value), perm)
+	err := os.WriteFile(path, []byte(value), perm)
 	if err != nil {
 		if !quiet {
 			log.Println("Error writing file " + path + ":  " + err.Error())
@@ -312,12 +311,12 @@ func WriteAndGoFmt(value string, path string, quiet bool, perm os.FileMode) erro
 
 // ReadFile reads a file
 func ReadFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 // ReadFileAndParse reads a file and parses it with json.Unmarshal
 func ReadFileAndParse(path string, v interface{}) (err error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -339,7 +338,7 @@ func ParseAndWriteFile(path string, v interface{}, perm os.FileMode) (err error)
 
 // WriteToFile writes a file
 func WriteToFile(value string, path string, perm os.FileMode) error {
-	err := ioutil.WriteFile(path, []byte(value), perm)
+	err := os.WriteFile(path, []byte(value), perm)
 	if err != nil {
 		log.Println("Error writing file " + path + ":  " + err.Error())
 		return err

--- a/core/fileCache/fileCache.go
+++ b/core/fileCache/fileCache.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/DanielRenne/GoCore/core/extensions"
 	"github.com/DanielRenne/GoCore/core/path"
@@ -116,7 +115,7 @@ func WriteJobCacheFile() (err error) {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(CACHE_JOBS+"/jobs.json", []byte(strjson), 0777)
+	err = os.WriteFile(CACHE_JOBS+"/jobs.json", []byte(strjson), 0777)
 	if err != nil {
 		return err
 	}
@@ -167,7 +166,7 @@ func WriteBootStrapCacheFile(key string) (err error) {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(CACHE_BOOTSTRAP_STORAGE_PATH+"/"+key+".json", []byte(strjson), 0777)
+		err = os.WriteFile(CACHE_BOOTSTRAP_STORAGE_PATH+"/"+key+".json", []byte(strjson), 0777)
 		if err != nil {
 			return err
 		}
@@ -285,7 +284,7 @@ func WriteManifestCacheFile(key string) (err error) {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(CACHE_MANIFEST_STORAGE_PATH+"/"+key+".json", []byte(strjson), 0777)
+		err = os.WriteFile(CACHE_MANIFEST_STORAGE_PATH+"/"+key+".json", []byte(strjson), 0777)
 		if err != nil {
 			return err
 		}

--- a/core/ginServer/ginServerHelpers.go
+++ b/core/ginServer/ginServerHelpers.go
@@ -4,8 +4,9 @@ package ginServer
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -134,12 +135,12 @@ func GetLocaleLanguage(c *gin.Context) (ll LocaleLanguage) {
 // GetRequestBody returns the body of the request as a string.
 func GetRequestBody(c *gin.Context) ([]byte, error) {
 	body := c.Request.Body
-	return ioutil.ReadAll(body)
+	return io.ReadAll(body)
 }
 
 // ReadHTMLFile reads a file from the path parameter and returns to the client as text/html.
 func ReadHTMLFile(path string, c *gin.Context) {
-	page, err := ioutil.ReadFile(path)
+	page, err := os.ReadFile(path)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -153,7 +154,7 @@ func ReadHTMLFile(path string, c *gin.Context) {
 
 // ReadJSFile reads a file from the path parameter and returns to the client as text/javascript.
 func ReadJSFile(path string, c *gin.Context) {
-	page, err := ioutil.ReadFile(path)
+	page, err := os.ReadFile(path)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -167,7 +168,7 @@ func ReadJSFile(path string, c *gin.Context) {
 
 // ReadFileBase64 reads a file and responds with a base64 encoded string.  Primarily used for jquery ajax response binary data blob encoding.
 func ReadFileBase64(path string, c *gin.Context) {
-	page, err := ioutil.ReadFile(path)
+	page, err := os.ReadFile(path)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -186,7 +187,7 @@ func RenderHTML(html string, c *gin.Context) {
 
 // ReadJSONFile reads a file from the path parameter and returns to the client application/json
 func ReadJSONFile(path string, c *gin.Context) {
-	js, err := ioutil.ReadFile(path)
+	js, err := os.ReadFile(path)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/core/serverSettings/serverSettings.go
+++ b/core/serverSettings/serverSettings.go
@@ -5,7 +5,7 @@ package serverSettings
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/DanielRenne/GoCore/core/path"
@@ -157,7 +157,7 @@ func Initialize(path string, configurationFile string) (err error) {
 	initPath(path)
 	fmt.Println("core serverSettings initialized.")
 
-	jsonData, err := ioutil.ReadFile(APP_LOCATION + "/" + configurationFile)
+	jsonData, err := os.ReadFile(APP_LOCATION + "/" + configurationFile)
 	if err != nil {
 		fmt.Println("Reading of webConfig.json failed:  " + err.Error())
 	}

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -2,9 +2,9 @@
 package utils
 
 import (
-	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -29,7 +29,7 @@ func RandStringRunes(n int) string {
 
 // ReplaceTokenInFile replaces a token in a file with a find/replace value
 func ReplaceTokenInFile(file string, find string, replaceWith string) {
-	input, err := ioutil.ReadFile(file)
+	input, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -42,7 +42,7 @@ func ReplaceTokenInFile(file string, find string, replaceWith string) {
 		}
 	}
 	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(file, []byte(output), 0644)
+	err = os.WriteFile(file, []byte(output), 0644)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/getAppTemplate/getAppTemplate.go
+++ b/getAppTemplate/getAppTemplate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -134,7 +133,7 @@ func readManifest() (coreManifest, error) {
 
 	var manifest coreManifest
 
-	jsonData, err := ioutil.ReadFile(manifestFileName)
+	jsonData, err := os.ReadFile(manifestFileName)
 	if err != nil {
 		fmt.Println("Reading of " + manifestFileName + " failed:  " + err.Error())
 		return manifest, err

--- a/getCore/getCore.go
+++ b/getCore/getCore.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -147,7 +146,7 @@ func readManifest() (coreManifest, error) {
 
 	var manifest coreManifest
 
-	jsonData, err := ioutil.ReadFile(manifestFileName)
+	jsonData, err := os.ReadFile(manifestFileName)
 	if err != nil {
 		fmt.Println("Reading of " + manifestFileName + " failed:  " + err.Error())
 		return manifest, err


### PR DESCRIPTION
`io/ioutil` has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.